### PR TITLE
Update eks_node_group.html.markdown to add amazon-linux-2023

### DIFF
--- a/website/docs/r/eks_node_group.html.markdown
+++ b/website/docs/r/eks_node_group.html.markdown
@@ -63,11 +63,12 @@ resource "aws_eks_node_group" "example" {
 
 ### Tracking the latest EKS Node Group AMI releases
 
-You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `amazon-linux-2` in the parameter name below with `amazon-linux-2-gpu` to retrieve the  accelerated AMI version and `amazon-linux-2-arm64` to retrieve the Arm version.
+You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `standard` in the parameter name below with `nvidia` to retrieve the  accelerated AMI version.
+Replace `x86_64`in the parameter name below with `arm64` to retrieve the Arm version.
 
 ```terraform
 data "aws_ssm_parameter" "eks_ami_release_version" {
-  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2/recommended/release_version"
+  name = "/aws/service/eks/optimized-ami/${aws_eks_cluster.example.version}/amazon-linux-2023/x86_64/standard/recommended/release_version"
 }
 
 resource "aws_eks_node_group" "example" {


### PR DESCRIPTION
### Original Sentences
You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `amazon-linux-2` in the parameter name below with `amazon-linux-2-gpu` to retrieve the  accelerated AMI version and `amazon-linux-2-arm64` to retrieve the Arm version.

### Issues in the Original Sentences
Outdated. Starting from EKS 1.30, `amazon linux 2023` is used instead of `amazon-linux-2` and the terraform provider uses by default `amazon linux 2023`

### Final Sentences
You can have the node group track the latest version of the Amazon EKS optimized Amazon Linux AMI for a given EKS version by querying an Amazon provided SSM parameter. Replace `standard` in the parameter name below with `nvidia` to retrieve the  accelerated AMI version.
Replace `x86_64`in the parameter name below with `arm64` to retrieve the Arm version.
### Conclusion
Aligning the documentation with the latest releases of terraform provider avoids confusion and prevents users to loose time to search the data needed.

Closes #0000

References
- https://aws.amazon.com/blogs/containers/amazon-eks-optimized-amazon-linux-2023-amis-now-available/
- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-standard.html